### PR TITLE
Create MAP lazily

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,11 +34,6 @@ function getValues(object) {
 class FSMerge {
   constructor(trees) {
     this._dirList = Array.isArray(trees) ? trees : [trees];
-    this.MAP = this._dirList.reduce(function(map, tree) {
-      let parsedTree = getRootAndPrefix(tree);
-      map[parsedTree.root] = parsedTree;
-      return map;
-    }, {});
   }
 
   readFileSync(filePath, options) {
@@ -54,7 +49,18 @@ class FSMerge {
     return result;
   }
 
+  _generateMap() {
+    this.MAP = this._dirList.reduce(function(map, tree) {
+      let parsedTree = getRootAndPrefix(tree);
+      map[parsedTree.root] = parsedTree;
+      return map;
+    }, {});
+  }
+
   readFileMeta(filePath, options) {
+    if (!this.MAP) {
+      this._generateMap();
+    }
     let { _dirList } = this;
     let result = null;
     let { basePath } = options || {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-merger",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Reads files from a real location",
   "main": "index.js",
   "author": "Sparshith NR",


### PR DESCRIPTION
This will allow FSMerger to be constructed at the time of Plugin's constructor and lazily generate the MAP whenever it is called first time.