### PR TITLE
[Feature] Provide a handler `at` to access files from specific inputPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ class FSMerge {
   constructor(trees) {
     this._dirList = Array.isArray(trees) ? trees : [trees];
     this.MAP = {};
+    this._atList = [];
     let self = this;
     this.fs = new Proxy(nodefs, {
       get(target, propertyName) {
@@ -90,6 +91,13 @@ class FSMerge {
       }
     }
     return result;
+  }
+
+  at(index) {
+    if(!this._atList[index]) {
+      this._atList[index] = new FSMerge(this._dirList[index]);
+    }
+    return this._atList[index]
   }
 
   _generateMap() {

--- a/tests/unit-test.js
+++ b/tests/unit-test.js
@@ -293,4 +293,17 @@ describe('fs-reader', function () {
       expect(fileList).to.be.deep.equal(walkList);
     });
   });
+
+  describe('at operation', function () {
+    let fsMerger = new FSMerge(['fixtures/test-1', 'fixtures/test-2', 'fixtures/test-3']);
+    it('at works', function() {
+      let content = fsMerger.at(0);
+      expect(content instanceof FSMerge).to.be.true;
+    });
+    it('can access file contents', function() {
+      let indexMerger = fsMerger.at(0);
+      let content = indexMerger.readFileSync('a.txt', 'utf-8');
+      expect(content).to.be.equal('hello');
+    });
+  });
 });


### PR DESCRIPTION
1. This feature will enable to read file from specific inputPath.
2. By doing this we still avoid user from using fs operation directly.