### PR TITLE
Accept absolute path in fs-merger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ function handleOperation(this: FSMerger & {[key: string]: any}, { target, proper
   if (!this.MAP) {
     this._generateMap();
   }
+  let fullPath = relativePath
 
   // at is a spcfical property exist in FSMerge which takes number as input do not perform path operation on it.
   if (propertyName == 'at' || !path.isAbsolute(relativePath)) {
@@ -75,7 +76,6 @@ function handleOperation(this: FSMerger & {[key: string]: any}, { target, proper
       return this[propertyName](relativePath, ...fsArguments);
     }
     let { _dirList } = this;
-    let fullPath = relativePath;
     for (let i=_dirList.length-1; i > -1; i--) {
       let { root } = this.PREFIXINDEXMAP[i];
       let tempPath = root + '/' + relativePath;
@@ -83,10 +83,8 @@ function handleOperation(this: FSMerger & {[key: string]: any}, { target, proper
         fullPath = tempPath;
       }
     }
-    return target[propertyName](fullPath, ...fsArguments);
-  } else {
-    throw new Error(`Relative path is expected, path ${relativePath} is an absolute path. inputPath gets prefixed to the reltivePath provided.`);
   }
+  return target[propertyName](fullPath, ...fsArguments);
 }
 
 class FSMerger {

--- a/tests/unit-test.js
+++ b/tests/unit-test.js
@@ -229,9 +229,16 @@ describe('fs-reader', function () {
       expect(content).to.be.true;
     });
 
-    it('absolute path throws error', function() {
+    it('absolute path is accepted', function() {
       let filepath = `${__dirname}/../fixtures/test-1`;
-      expect( ()=>{fsMerger.fs.existsSync(filepath)}).to.throw(`Relative path is expected, path ${filepath} is an absolute path. inputPath gets prefixed to the reltivePath provided.`);
+      expect(fsMerger.fs.existsSync(filepath)).to.be.true;
+    });
+
+    it('absolute path is accepted only with allowed operations', function() {
+      let filepath = `${__dirname}/../fixtures/test-1`;
+      expect(()=>{
+        fsMerger.fs.rmdirSync(filepath);
+      }).to.throw(`Operation rmdirSync is not allowed with FSMerger.fs. Allowed operations are readFileSync,existsSync,lstatSync,statSync,readdirSync,readdir,readFileMeta,entries,at`);
     });
 
     it('writeFileSync operation must throw error', function () {


### PR DESCRIPTION
* Will help in broccoli plugins which needs to access external resources
* can act like a `fs` replacer with limited set of operations
* Added additional tests