### PR TITLE
Ensure all of `dist/` is published to npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Reads files from a real location",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist/"
+  ],
   "author": "Sparshith NR",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Previously, the `d.ts` and `.map` files were being excluded.
