### PR TITLE
Failing test demonstrating CWD "bleed through"

### DIFF
--- a/tests/unit-test.js
+++ b/tests/unit-test.js
@@ -224,11 +224,20 @@ describe('fs-reader', function () {
   });
 
   describe('Verify few fs operations', function() {
-    let fsMerger = new FSMerge(['fixtures/test-1', 'fixtures/test-2', 'fixtures/test-3']);
+    let fsMerger;
+
+    beforeEach(function() {
+      fsMerger = new FSMerge(['fixtures/test-1', 'fixtures/test-2', 'fixtures/test-3']);
+    });
 
     it('existsSync works', function() {
       let content = fsMerger.fs.existsSync('test-1');
       expect(content).to.be.true;
+    });
+
+    it('existsSync does not bleed through to process.cwd() when the path is missing', function() {
+      let content = fsMerger.fs.existsSync('src');
+      expect(content).to.be.false;
     });
 
     it('absolute path is accepted', function() {


### PR DESCRIPTION
The various FS APIs that are wrapped do not properly scope requests to the input source directories.

For example, given this directory structure:

```
├── bar
│   └── baz
├── foo
└── qux
```

If the current working directory is the directory above, the following returns the incorrect result:

```
let merger = new FSMerge(['bar', 'qux');
merger.fs.existsSync('foo');

// -> currently returns `true`, but should obviously be `false
```

If ran from a working directory that did not have a `foo/` folder, it would return the correct result.

References:

* https://github.com/broccolijs/broccoli-funnel/pull/136
* https://github.com/embroider-build/embroider/issues/764
* https://github.com/embroider-build/embroider/pull/766
