### PR TITLE
Refactors to simplify the FS proxy implementation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ function handleFSOperation(
       fullPath = tempPath;
 
       if(fs.existsSync(tempPath)) {
-        // break;
+        break;
       }
     }
 

--- a/tests/unit-test.js
+++ b/tests/unit-test.js
@@ -224,11 +224,20 @@ describe('fs-reader', function () {
   });
 
   describe('Verify few fs operations', function() {
-    let fsMerger = new FSMerge(['fixtures/test-1', 'fixtures/test-2', 'fixtures/test-3']);
+    let fsMerger;
+
+    beforeEach(function() {
+      fsMerger = new FSMerge(['fixtures/test-1', 'fixtures/test-2', 'fixtures/test-3']);
+    });
 
     it('existsSync works', function() {
       let content = fsMerger.fs.existsSync('test-1');
       expect(content).to.be.true;
+    });
+
+    it('existsSync does not bleed through to process.cwd() when the path is missing', function() {
+      let content = fsMerger.fs.existsSync('src');
+      expect(content).to.be.false;
     });
 
     it('absolute path is accepted', function() {


### PR DESCRIPTION
This fixes two major bugs in the prior implementation:

#### CWD "bleed through"

Prior to these changes the various FS APIs that are wrapped do not properly scope requests to the input source directories.

For example, given this directory structure:

```
├── bar
│   └── baz
├── foo
└── qux
```

If the current working directory is the directory above, the following returns the incorrect result:

```
let merger = new FSMerge(['bar', 'qux');
merger.fs.existsSync('foo');

// -> currently returns `true`, but should obviously be `false
```

If ran from a working directory that did not have a `foo/` folder, it would return the correct result.

References:

* https://github.com/broccolijs/broccoli-funnel/pull/136
* https://github.com/embroider-build/embroider/issues/764
* https://github.com/embroider-build/embroider/pull/766
* Closes #43

#### Broken "last one wins" semantics

Prior to these changes when using `existsSync`, `lstatSync`, or `statSync` would _only_ work if the **first** argument to `new FSMerger()` contained the file in question. Breaking both the fundamental purpose of this library _and_ the "last one wins" semantics.

---

TODO:

- [x] Use typescript to help enforce that all valid operations are accounted for
- [x] Remove defaulting of `fullPath = relativePath` in `handleFSOperation` (this will "Fix" the bleed through issue, but causes knock on failures)
- [x] Include previously failing tests from https://github.com/SparshithNR/fs-merger/pull/43