### PR TITLE
Remove unused dependencies and update remaining to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "mocha": "^6.1.4",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
+    "rimraf": "^2.6.3",
     "ts-node": "^8.4.1",
     "typescript": "^3.6.2"
   },
@@ -45,7 +46,6 @@
     "broccoli-node-info": "^2.1.0",
     "fs-extra": "^8.0.1",
     "fs-tree-diff": "^2.0.1",
-    "rimraf": "^2.6.3",
     "walk-sync": "^2.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "broccoli-node-info": "^2.1.0",
     "fs-extra": "^8.0.1",
     "fs-tree-diff": "^2.0.1",
-    "walk-sync": "^2.0.2"
+    "walk-sync": "^2.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1963,7 +1963,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-walk-sync@^2.0.2:
+walk-sync@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-2.2.0.tgz#80786b0657fcc8c0e1c0b1a042a09eae2966387a"
   integrity sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==


### PR DESCRIPTION
- Move rimraf to devDependencies
- Update minimum version of walk-sync to 2.2.0

Note: we cannot update fs-extra to 9.x due to it dropping support for Node < 10.
